### PR TITLE
Added possibility to post offer at facebook once again

### DIFF
--- a/php/portal/bin/offers
+++ b/php/portal/bin/offers
@@ -2,8 +2,10 @@
 <?php
 
 use App\Offers\Command\Offer\AutoRenewOffers;
+use App\Offers\Command\Offer\PostOfferAtFacebookGroup;
 use App\Offers\Command\Offer\RemoveOffer;
 use App\Offers\Command\Offer\ThumbnailRegenerate as OfferThumbnailRegenerate;
+use App\Offers\Command\Offer\TweetAboutOffer;
 use App\Offers\Command\Specialization\RemoveTwitterChannel;
 use App\Offers\Command\Specialization\SetTwitterChannel;
 use App\Offers\Command\Specialization\ThumbnailRegenerate;
@@ -29,7 +31,8 @@ $projectRootPath = dirname(__DIR__);
 
 require $projectRootPath . '/src/autoload.php';
 
-$itOffers = symfony(bootstrap($projectRootPath))->getContainer()->get(ITOffersOnline::class);
+$symfony = symfony(bootstrap($projectRootPath));
+$itOffers = $symfony->getContainer()->get(ITOffersOnline::class);
 
 $application = new Application('itoffers.online - Offers');
 
@@ -41,6 +44,8 @@ $application->add(new RemoveFacebookChannel($itOffers->offers()));
 $application->add(new RemoveTwitterChannel($itOffers->offers()));
 $application->add(new PerformanceCheckCommand($itOffers->offers(), $itOffers->config()));
 $application->add(new RemoveOffer($itOffers->offers()));
+$application->add(new PostOfferAtFacebookGroup($itOffers->offers(), $symfony->getContainer()->get('twig')));
+$application->add(new TweetAboutOffer($itOffers->offers(), $symfony->getContainer()->get('twig')));
 $application->add(new OfferThumbnailRegenerate(
     $itOffers->offers(),
     new ImagineOfferThumbnail(

--- a/php/portal/resources/templates/en-US/ui/offers/alert/error_post_facebook.txt
+++ b/php/portal/resources/templates/en-US/ui/offers/alert/error_post_facebook.txt
@@ -1,0 +1,1 @@
+Ops, it looks there was an issue with posting your offer at Facebook, our team is already looking into it!

--- a/php/portal/resources/templates/en-US/ui/offers/alert/error_post_twitter.txt
+++ b/php/portal/resources/templates/en-US/ui/offers/alert/error_post_twitter.txt
@@ -1,0 +1,1 @@
+Ops, it looks there was an issue with posting your offer at Twitter, our team is already looking into it!

--- a/php/portal/resources/templates/en-US/ui/offers/offer/new.html.twig
+++ b/php/portal/resources/templates/en-US/ui/offers/offer/new.html.twig
@@ -127,7 +127,12 @@
                 </div>
                 {{ form_row(form.position.seniorityLevel, {attr: {'value' : 0}}) }}
 
-                {{ form_row(form.position.name, {label: "Job Title", attr:{placeholder: "Developer"}}) }}
+                {{ form_row(
+                    form.position.name,
+                    {label: "Job Title", attr:{placeholder: "Developer"},
+                    help: "Don't put seniority level in Job Title, instead select it from the buttons above the field."
+                })
+                }}
                 {{ form_row(form.contract, {label: "Job Type"}) }}
             </div>
         </div>

--- a/php/portal/resources/templates/en-US/ui/theme/base.html.twig
+++ b/php/portal/resources/templates/en-US/ui/theme/base.html.twig
@@ -54,9 +54,9 @@
     {% endblock %}
 
     {% if app.session is not null and app.session.started %}
-        {% if app.session.flashbag.peek('success')|length or app.session.flashbag.peek('error')|length or app.session.flashbag.peek('warning')|length %}
+        {% if app.session.flashbag.peek('success')|length or app.session.flashbag.peek('danger')|length or app.session.flashbag.peek('warning')|length %}
             <div class="container-fluid pt-2 pb-2 bg-light">
-            {% for label, messages in app.flashes(['warning', 'error', 'success']) %}
+            {% for label, messages in app.flashes(['warning', 'danger', 'success']) %}
                 {% for message in messages %}
                     <div class="container">
                         <div data-alert-{{ label }} class="alert alert-{{ label }} text-center m-0">

--- a/php/portal/src/App/Offers/Command/Offer/PostOfferAtFacebookGroup.php
+++ b/php/portal/src/App/Offers/Command/Offer/PostOfferAtFacebookGroup.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the itoffers.online project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Offers\Command\Offer;
+
+use ITOffers\Offers\Application\Command\Facebook\PagePostOfferAtGroup;
+use ITOffers\Offers\Application\FeatureToggle\PostOfferAtFacebookGroupFeature;
+use ITOffers\Offers\Offers;
+use function mb_strtolower;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+use Twig\Environment;
+
+final class PostOfferAtFacebookGroup extends Command
+{
+    public const NAME = 'offer:facebook:post';
+
+    /**
+     * @var string
+     */
+    protected static $defaultName = self::NAME;
+
+    private Offers $offers;
+
+    private SymfonyStyle $io;
+
+    private Environment $twig;
+
+    public function __construct(Offers $offers, Environment $twig)
+    {
+        parent::__construct();
+
+        $this->offers = $offers;
+        $this->twig = $twig;
+    }
+
+    protected function configure() : void
+    {
+        $this
+            ->setDescription('Post offer at Facebook group')
+            ->addArgument('slug', InputArgument::REQUIRED, 'Offer slug')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output) : void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $this->io->note('Post offer at Facebook group');
+
+        if ($input->isInteractive()) {
+            $answer = $this->io->ask('Are you sure you want to post this offer at Facebook group?', 'yes');
+
+            if (mb_strtolower($answer) !== 'yes') {
+                $this->io->note('Ok, offer was not posted');
+
+                return 1;
+            }
+        }
+
+        if (!$offer = $this->offers->offerQuery()->findBySlug($input->getArgument('slug'))) {
+            $this->io->error(sprintf('Offer with slug "%s" does not exists.', $input->getArgument('slug')));
+
+            return 1;
+        }
+
+        if (!$this->offers->featureQuery()->isEnabled(PostOfferAtFacebookGroupFeature::NAME)) {
+            $this->io->error('Posting offers at facebook feature is currently disabled.');
+
+            return 1;
+        }
+
+        try {
+            $this->offers->handle(new PagePostOfferAtGroup(
+                $offer->id()->toString(),
+                $this->twig->render('@offers/facebook/offer.txt.twig', ['offer' => $offer]),
+            ));
+        } catch (Throwable $e) {
+            $this->io->error('Can\'t remove offer, check logs for more details.');
+
+            return 1;
+        }
+
+        $this->io->success('Offer removed');
+
+        return 0;
+    }
+}

--- a/php/portal/src/App/Offers/Command/Offer/TweetAboutOffer.php
+++ b/php/portal/src/App/Offers/Command/Offer/TweetAboutOffer.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the itoffers.online project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Offers\Command\Offer;
+
+use ITOffers\Offers\Application\Command\Twitter\TweetAboutOffer as TweetAboutOfferCommand;
+use ITOffers\Offers\Application\FeatureToggle\TweetAboutOfferFeature;
+use ITOffers\Offers\Offers;
+use function mb_strtolower;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+use Twig\Environment;
+
+final class TweetAboutOffer extends Command
+{
+    public const NAME = 'offer:twitter:tweet';
+
+    /**
+     * @var string
+     */
+    protected static $defaultName = self::NAME;
+
+    private Offers $offers;
+
+    private SymfonyStyle $io;
+
+    private Environment $twig;
+
+    public function __construct(Offers $offers, Environment $twig)
+    {
+        parent::__construct();
+
+        $this->offers = $offers;
+        $this->twig = $twig;
+    }
+
+    protected function configure() : void
+    {
+        $this
+            ->setDescription('Tweet about offer')
+            ->addArgument('slug', InputArgument::REQUIRED, 'Offer slug')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output) : void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $this->io->note('Tweet about offer');
+
+        if ($input->isInteractive()) {
+            $answer = $this->io->ask('Are you sure you want to tweet about this offer?', 'yes');
+
+            if (mb_strtolower($answer) !== 'yes') {
+                $this->io->note('Ok, offer was not posted');
+
+                return 1;
+            }
+        }
+
+        if (!$offer = $this->offers->offerQuery()->findBySlug($input->getArgument('slug'))) {
+            $this->io->error(sprintf('Offer with slug "%s" does not exists.', $input->getArgument('slug')));
+
+            return 1;
+        }
+
+        if (!$this->offers->featureQuery()->isEnabled(TweetAboutOfferFeature::NAME)) {
+            $this->io->error('Tweeting about offers feature is currently disabled.');
+
+            return 1;
+        }
+
+        try {
+            $this->offers->handle(new TweetAboutOfferCommand(
+                $offer->id()->toString(),
+                $this->twig->render('@offers/twitter/offer.txt.twig', ['offer' => $offer]),
+            ));
+        } catch (Throwable $e) {
+            $this->io->error('Can\'t remove offer, check logs for more details.');
+
+            return 1;
+        }
+
+        $this->io->success('Offer removed');
+
+        return 0;
+    }
+}

--- a/php/portal/src/App/Offers/Controller/OfferController.php
+++ b/php/portal/src/App/Offers/Controller/OfferController.php
@@ -177,18 +177,28 @@ final class OfferController extends AbstractController
 
                 $offer = $this->itoffers->offers()->offerQuery()->findById($offerId);
 
-                if ($this->itoffers->offers()->featureQuery()->isEnabled(PostOfferAtFacebookGroupFeature::NAME) && (bool) $offerData['channels']['facebook_group']) {
-                    $this->itoffers->offers()->handle(new PagePostOfferAtGroup(
-                        $offerId,
-                        $this->renderView('@offers/facebook/page/group/offer.txt.twig', ['offer' => $offer]),
-                    ));
+                try {
+                    if ($this->itoffers->offers()->featureQuery()->isEnabled(PostOfferAtFacebookGroupFeature::NAME) && (bool)$offerData['channels']['facebook_group']) {
+                        $this->itoffers->offers()->handle(new PagePostOfferAtGroup(
+                            $offerId,
+                            $this->renderView('@offers/facebook/page/group/offer.txt.twig', ['offer' => $offer]),
+                        ));
+                    }
+                } catch (\Throwable $throwable) {
+                    $this->logger->critical('Could not post offer at Facebook.', ['class' => \get_class($throwable), 'exception' => $throwable]);
+                    $this->addFlash('danger', $this->renderView('@offers/alert/error_post_facebook.txt'));
                 }
 
-                if ($this->itoffers->offers()->featureQuery()->isEnabled(TweetAboutOfferFeature::NAME) && (bool) $offerData['channels']['twitter']) {
-                    $this->itoffers->offers()->handle(new TweetAboutOffer(
-                        $offerId,
-                        $this->renderView('@offers/twitter/offer.txt.twig', ['offer' => $offer]),
-                    ));
+                try {
+                    if ($this->itoffers->offers()->featureQuery()->isEnabled(TweetAboutOfferFeature::NAME) && (bool)$offerData['channels']['twitter']) {
+                        $this->itoffers->offers()->handle(new TweetAboutOffer(
+                            $offerId,
+                            $this->renderView('@offers/twitter/offer.txt.twig', ['offer' => $offer]),
+                        ));
+                    }
+                } catch (\Throwable $throwable) {
+                    $this->logger->critical('Could not post offer at Twitter.', ['class' => \get_class($throwable), 'exception' => $throwable]);
+                    $this->addFlash('danger', $this->renderView('@offers/alert/error_post_twitter.txt'));
                 }
 
                 return $this->redirectToRoute('offer_success', ['specSlug' => $specSlug, 'offer-slug' => $offer->slug()]);

--- a/php/portal/src/App/Offers/Form/Type/Offer/PositionType.php
+++ b/php/portal/src/App/Offers/Form/Type/Offer/PositionType.php
@@ -18,8 +18,10 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class PositionType extends AbstractType
 {
@@ -35,6 +37,18 @@ final class PositionType extends AbstractType
                 'constraints' => [
                     new Length(['min' => 3, 'max' => 255]),
                     new NotContainsEmoji(),
+                    new Callback([
+                        'callback' => function ($object, ExecutionContextInterface $context, $payload) {
+                            $forbiddenWords = ['senior', 'junior', 'intern', 'mid', 'expert', 'ninja'];
+
+                            foreach ($forbiddenWords as $forbiddenWord) {
+                                if (\mb_strpos(\mb_strtolower($object), $forbiddenWord) !== false) {
+                                    $context->buildViolation('Please don\'t put seniority level "' . \ucfirst($forbiddenWord) . '" into job title, there is separated option for it.')
+                                        ->addViolation();
+                                }
+                            }
+                        },
+                    ]),
                 ],
             ])
         ;

--- a/php/portal/tests/App/Tests/Offers/Integration/Form/PositionTypeTest.php
+++ b/php/portal/tests/App/Tests/Offers/Integration/Form/PositionTypeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the itoffers.online project.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Offers\Integration\Form;
+
+use App\Offers\Form\Type\Offer\PositionType;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Validator\Validation;
+
+final class PositionTypeTest extends TypeTestCase
+{
+    protected function getExtensions() : array
+    {
+        return [
+            new ValidatorExtension(Validation::createValidator()),
+        ];
+    }
+
+    public function test_submit_valid_position() : void
+    {
+        $formData = [
+            'seniorityLevel' => 0,
+            'name' => 'Software Developer',
+        ];
+        $form = $this->factory->create(PositionType::class, null, []);
+        $form->submit($formData);
+        $this->assertTrue($form->isSynchronized());
+        $this->assertTrue($form->isValid());
+        $this->assertTrue($form->get('seniorityLevel')->isValid());
+        $this->assertTrue($form->get('name')->isValid());
+    }
+
+    /**
+     * @dataProvider seniorityLevels
+     */
+    public function test_submit_position_with_seniority_level_in_the_name(string $seniorityLevel) : void
+    {
+        $formData = [
+            'seniorityLevel' => 0,
+            'name' => $seniorityLevel . ' Software Developer',
+        ];
+        $form = $this->factory->create(PositionType::class, null, []);
+        $form->submit($formData);
+        $this->assertTrue($form->isSynchronized());
+        $this->assertFalse($form->isValid());
+        $this->assertTrue($form->get('seniorityLevel')->isValid());
+        $this->assertFalse($form->get('name')->isValid());
+    }
+
+    public function seniorityLevels() : \Generator
+    {
+        yield [
+            'ninja',
+        ];
+        yield [
+            'intern',
+        ];
+        yield [
+            'junior',
+        ];
+        yield [
+            'senior',
+        ];
+        yield [
+            'mid',
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds also 

* forbidden words validator in job offer title (to prevent using seniority level that is different field)
* CLI commands to post offer at twitter/facebook in case of error
* catching exceptions when posting at twitter/facebook and showing proper error message